### PR TITLE
Refactor tests

### DIFF
--- a/tests/CopyFilesTaskIntegrationTest.php
+++ b/tests/CopyFilesTaskIntegrationTest.php
@@ -20,7 +20,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function copyFileDataProvider(): Generator
 	{
 		yield 'copy file' => [
-			'target' => 'testCopyFile',
+			'target' => 'copy-file',
 			'sourceFileName' => '/foo',
 			'targetFileName' => '/foo-copy',
 			'existingSourceFileContents' => 'FOO',
@@ -31,7 +31,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		];
 
 		yield 'copy file with absolute path' => [
-			'target' => 'testCopyFileWithAbsolutePath',
+			'target' => 'copy-file-with-absolute-path',
 			'sourceFileName' => '/foo',
 			'targetFileName' => '/foo-copy',
 			'existingSourceFileContents' => 'FOO',
@@ -42,7 +42,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		];
 
 		yield 'target file exists' => [
-			'target' => 'testTargetFileExists',
+			'target' => 'target-file-exists',
 			'sourceFileName' => '/new',
 			'targetFileName' => '/existing',
 			'existingSourceFileContents' => 'NEW',
@@ -53,7 +53,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		];
 
 		yield 'target file exists skip' => [
-			'target' => 'testTargetFileExistsSkip',
+			'target' => 'target-file-exists-skip',
 			'sourceFileName' => '/new',
 			'targetFileName' => '/existing',
 			'existingSourceFileContents' => 'NEW',
@@ -64,7 +64,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		];
 
 		yield 'target file exists replace' => [
-			'target' => 'testTargetFileExistsReplace',
+			'target' => 'target-file-exists-replace',
 			'sourceFileName' => '/new',
 			'targetFileName' => '/existing',
 			'existingSourceFileContents' => 'NEW',
@@ -124,7 +124,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		file_put_contents($targetFilePath, 'EXISTING');
 
 		$tester = new PhingTester(__DIR__ . '/copy-files-task-integration-test.xml', self::TEMP_DIRECTORY_PATH);
-		$target = __FUNCTION__;
+		$target = 'target-file-exists-fail';
 
 		$tester->expectFailedBuild($target);
 
@@ -149,7 +149,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		}
 
 		$tester = new PhingTester(__DIR__ . '/copy-files-task-integration-test.xml', self::TEMP_DIRECTORY_PATH);
-		$target = __FUNCTION__;
+		$target = 'copy-multiple-files';
 		$tester->executeTarget($target);
 
 		Assert::assertFileEquals($sourceFooFilePath, $targetFooFilePath);
@@ -171,7 +171,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		file_put_contents($targetBarFilePath, 'BAR-EXISTING');
 
 		$tester = new PhingTester(__DIR__ . '/copy-files-task-integration-test.xml', self::TEMP_DIRECTORY_PATH);
-		$target = __FUNCTION__;
+		$target = 'replace-multiple-files-with-existing-targets';
 		$tester->executeTarget($target);
 
 		Assert::assertFileEquals($sourceFooFilePath, $targetFooFilePath);
@@ -201,7 +201,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		file_put_contents($targetDefaultFilePath, 'DEFAULT-EXISTING');
 
 		$tester = new PhingTester(__DIR__ . '/copy-files-task-integration-test.xml', self::TEMP_DIRECTORY_PATH);
-		$target = __FUNCTION__;
+		$target = 'copy-multiple-files-with-existing-targets-using-different-modes';
 		$tester->executeTarget($target);
 
 		Assert::assertFileExists($targetSkipFilePath);
@@ -233,7 +233,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		file_put_contents($targetDefaultFilePath, 'DEFAULT-EXISTING');
 
 		$tester = new PhingTester(__DIR__ . '/copy-files-task-integration-test.xml', self::TEMP_DIRECTORY_PATH);
-		$target = __FUNCTION__;
+		$target = 'copy-multiple-files-with-existing-targets-using-different-modes-with-replace-fallback';
 		$tester->executeTarget($target);
 
 		Assert::assertFileExists($targetSkipFilePath);
@@ -251,7 +251,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testCopyNonExistentFile(): void
 	{
 		$tester = new PhingTester(__DIR__ . '/copy-files-task-integration-test.xml');
-		$target = __FUNCTION__;
+		$target = 'copy-non-existent-file';
 
 		$tester->expectFailedBuild($target);
 
@@ -261,7 +261,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testCopyMultipleNonExistentFiles(): void
 	{
 		$tester = new PhingTester(__DIR__ . '/copy-files-task-integration-test.xml');
-		$target = __FUNCTION__;
+		$target = 'copy-multiple-non-existent-files';
 
 		$tester->expectFailedBuild($target);
 
@@ -279,7 +279,7 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 		}
 
 		$tester = new PhingTester(__DIR__ . '/copy-files-task-integration-test.xml', self::TEMP_DIRECTORY_PATH);
-		$target = __FUNCTION__;
+		$target = 'copy-file-to-non-existing-directory';
 
 		$tester->expectFailedBuild($target);
 
@@ -292,22 +292,22 @@ class CopyFilesTaskIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function throwBuildExceptionDataProvider(): Generator
 	{
 		yield 'missing copy file element' => [
-			'target' => 'testMissingCopyFileElement',
+			'target' => 'missing-copy-file-element',
 			'expectedMessagePatternRegExp' => '~one.+<file>.+expected~',
 		];
 
 		yield 'missing source' => [
-			'target' => 'testMissingSource',
+			'target' => 'missing-source',
 			'expectedMessagePatternRegExp' => '~<file>.+`source`~',
 		];
 
 		yield 'missing target' => [
-			'target' => 'testMissingTarget',
+			'target' => 'missing-target',
 			'expectedMessagePatternRegExp' => '~<file>.+`target`~',
 		];
 
 		yield 'invalid file exists mode' => [
-			'target' => 'testInvalidFileExistsMode',
+			'target' => 'invalid-file-exists-mode',
 			'expectedMessagePatternRegExp' => '~invalid.+mode~i',
 		];
 	}

--- a/tests/copy-files-task-integration-test.xml
+++ b/tests/copy-files-task-integration-test.xml
@@ -3,57 +3,57 @@
 
 	<taskdef name="copy-files" classname="VasekPurchart\Phing\CopyFiles\CopyFilesTask"/>
 
-	<target name="testCopyFile">
+	<target name="copy-file">
 		<copy-files>
 			<file source="foo" target="foo-copy"/>
 		</copy-files>
 	</target>
 
-	<target name="testCopyFileWithAbsolutePath">
+	<target name="copy-file-with-absolute-path">
 		<copy-files>
 			<file source="${project.basedir}/foo" target="${project.basedir}/foo-copy"/>
 		</copy-files>
 	</target>
 
-	<target name="testTargetFileExists">
+	<target name="target-file-exists">
 		<copy-files>
 			<file source="new" target="existing"/>
 		</copy-files>
 	</target>
 
-	<target name="testTargetFileExistsSkip">
+	<target name="target-file-exists-skip">
 		<copy-files existsmode="skip">
 			<file source="new" target="existing"/>
 		</copy-files>
 	</target>
 
-	<target name="testTargetFileExistsReplace">
+	<target name="target-file-exists-replace">
 		<copy-files existsmode="replace">
 			<file source="new" target="existing"/>
 		</copy-files>
 	</target>
 
-	<target name="testTargetFileExistsFail">
+	<target name="target-file-exists-fail">
 		<copy-files existsmode="fail">
 			<file source="new" target="existing"/>
 		</copy-files>
 	</target>
 
-	<target name="testCopyMultipleFiles">
+	<target name="copy-multiple-files">
 		<copy-files>
 			<file source="foo" target="foo-copy"/>
 			<file source="bar" target="bar-copy"/>
 		</copy-files>
 	</target>
 
-	<target name="testReplaceMultipleFilesWithExistingTargets">
+	<target name="replace-multiple-files-with-existing-targets">
 		<copy-files existsmode="replace">
 			<file source="foo-new" target="foo-existing"/>
 			<file source="bar-new" target="bar-existing"/>
 		</copy-files>
 	</target>
 
-	<target name="testCopyMultipleFilesWithExistingTargetsUsingDifferentModes">
+	<target name="copy-multiple-files-with-existing-targets-using-different-modes">
 		<copy-files>
 			<file source="skip-new" target="skip-existing" existsmode="skip"/>
 			<file source="replace-new" target="replace-existing" existsmode="replace"/>
@@ -61,7 +61,7 @@
 		</copy-files>
 	</target>
 
-	<target name="testCopyMultipleFilesWithExistingTargetsUsingDifferentModesWithReplaceFallback">
+	<target name="copy-multiple-files-with-existing-targets-using-different-modes-with-replace-fallback">
 		<copy-files existsmode="replace">
 			<file source="skip-new" target="skip-existing" existsmode="skip"/>
 			<file source="replace-new" target="replace-existing" existsmode="replace"/>
@@ -69,43 +69,43 @@
 		</copy-files>
 	</target>
 
-	<target name="testCopyNonExistentFile">
+	<target name="copy-non-existent-file">
 		<copy-files>
 			<file source="XXX" target="YYY"/>
 		</copy-files>
 	</target>
 
-	<target name="testCopyMultipleNonExistentFiles">
+	<target name="copy-multiple-non-existent-files">
 		<copy-files>
 			<file source="FOO" target="LOREM"/>
 			<file source="BAR" target="LOREM"/>
 		</copy-files>
 	</target>
 
-	<target name="testCopyFileToNonExistingDirectory">
+	<target name="copy-file-to-non-existing-directory">
 		<copy-files>
 			<file source="foo" target="non-existing-directory/foo-copy"/>
 		</copy-files>
 	</target>
 
-	<target name="testMissingCopyFileElement">
+	<target name="missing-copy-file-element">
 		<copy-files>
 		</copy-files>
 	</target>
 
-	<target name="testMissingSource">
+	<target name="missing-source">
 		<copy-files>
 			<file target="BAR"/>
 		</copy-files>
 	</target>
 
-	<target name="testMissingTarget">
+	<target name="missing-target">
 		<copy-files>
 			<file source="FOO"/>
 		</copy-files>
 	</target>
 
-	<target name="testInvalidFileExistsMode">
+	<target name="invalid-file-exists-mode">
 		<copy-files existsmode="invalid-mode">
 			<file source="new" target="existing"/>
 		</copy-files>


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks